### PR TITLE
Stop animations on unmount.

### DIFF
--- a/src/lib/components/Animated-Number.js
+++ b/src/lib/components/Animated-Number.js
@@ -42,6 +42,10 @@ class AnimatedNumber extends Component {
     if (prevProps.value !== this.props.value) this.animateValue();
   };
 
+  componentWillUnmount = () => {
+    this.stopAnimation();
+  };
+
   target = {
     animatedValue: 0,
   };
@@ -52,12 +56,22 @@ class AnimatedNumber extends Component {
     this.setState({ animatedValue });
   };
 
+  stopAnimation = () => {
+    if (!this.instance) return;
+
+    this.instance.pause();
+    this.instance.reset();
+    delete this.instance;
+  };
+
   animateValue = () => {
+    this.stopAnimation();
+
     const {
       duration, begin, easing, complete, run, delay, value,
     } = this.props;
 
-    anime({
+    this.instance = anime({
       targets: this.target,
       animatedValue: value,
       duration,


### PR DESCRIPTION
This is probably a better fix for #19 than #20. #20 avoids the error by preventing the (ongoing) animations from affecting the state, this stops the animation from running on unmount so that it doesn't try to update the state at all.